### PR TITLE
Conversion error description

### DIFF
--- a/FMI2_to_VDM/src/main/scripts/VDMCheck2.sh
+++ b/FMI2_to_VDM/src/main/scripts/VDMCheck2.sh
@@ -76,7 +76,7 @@ case $(file -b --mime-type $FILE) in
 	;;
 		
 	*)
-		echo "Input is neither a ZIP nor an XML file?"
+		echo "Input is neither a ZIP nor an XML file?\n"
 		exit 1
 	;;
 esac
@@ -96,7 +96,7 @@ esac
 	
 	if ! java -jar fmi2vdm-${project.version}.jar "$XML" "$VAR" >$VDM
 	then
-		echo "Problem converting modelDescription.xml to VDM-SL?"
+		echo "Problem converting modelDescription.xml to VDM-SL? This might be caused by a spelling mistake."
 		exit 2
 	fi
 	

--- a/FMI2_to_VDM/src/main/scripts/VDMCheck2.sh
+++ b/FMI2_to_VDM/src/main/scripts/VDMCheck2.sh
@@ -76,7 +76,7 @@ case $(file -b --mime-type $FILE) in
 	;;
 		
 	*)
-		echo "Input is neither a ZIP nor an XML file?\n"
+		echo "Input is neither a ZIP nor an XML file?"
 		exit 1
 	;;
 esac

--- a/FMI3_to_VDM/src/main/scripts/VDMCheck3.sh
+++ b/FMI3_to_VDM/src/main/scripts/VDMCheck3.sh
@@ -96,7 +96,7 @@ esac
 	
 	if ! java -jar fmi3vdm-${project.version}.jar "$XML" "$VAR" >$VDM
 	then
-		echo "Problem converting modelDescription.xml to VDM-SL?"
+		echo "Problem converting modelDescription.xml to VDM-SL? This might be caused by a spelling mistake."
 		exit 2
 	fi
 	


### PR DESCRIPTION
When figuring out how to create a correct model description I encounter the error: Problem converting to vdm-sl. This is usually due to a spelling mistake in the model description file. Last time it was **unkown** vs **unknown**.
This pull request is just a small hint on what to look for, when you encounter this error. 