### PR TITLE
set all version numbers to 1.0.0-SNAPSHOT

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,3 +67,11 @@ or
 VDMCheck2.sh
 ```
 This will print the usage.
+
+## Release 
+
+~~~bash
+mvn -Dmaven.repo.local=repository release:clean
+mvn -Dmaven.repo.local=repository release:prepare -DreleaseVersion=${RELEASE_VER} -DdevelopmentVersion=${NEW_DEV_VER}
+mvn -Dmaven.repo.local=repository release:perform
+~~~

--- a/fmi2/cosim-model/pom.xml
+++ b/fmi2/cosim-model/pom.xml
@@ -5,12 +5,11 @@
 	<parent>
 		<groupId>org.into-cps.vdmcheck</groupId>
 		<artifactId>fmi2</artifactId>
-		<version>1.0.0</version>
+		<version>1.0.0-SNAPSHOT</version>
 	</parent>
 
 	<groupId>org.into-cps.vdmcheck.fmi2</groupId>
 	<artifactId>cosim-model</artifactId>
-	<version>0.0.1-SNAPSHOT</version>
 	<build>
 		<directory>generated</directory>
 		<plugins>

--- a/fmi2/cosim2vdm/pom.xml
+++ b/fmi2/cosim2vdm/pom.xml
@@ -4,10 +4,9 @@
   <parent>
     <groupId>org.into-cps.vdmcheck</groupId>
     <artifactId>fmi2</artifactId>
-    <version>1.0.0</version>
+    <version>1.0.0-SNAPSHOT</version>
   </parent>
 
   <groupId>org.into-cps.vdmcheck.fmi2</groupId>
   <artifactId>cosim2vdm</artifactId>
-  <version>0.0.1-SNAPSHOT</version>
 </project>

--- a/fmi2/fmi2vdm/pom.xml
+++ b/fmi2/fmi2vdm/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.into-cps.vdmcheck</groupId>
 		<artifactId>fmi2</artifactId>
-		<version>1.0.0</version>
+		<version>1.0.0-SNAPSHOT</version>
 	</parent>
 
 	<groupId>org.into-cps.vdmcheck.fmi2</groupId>
@@ -15,13 +15,12 @@
 		<maven.build.timestamp.format>yyMMdd</maven.build.timestamp.format>
 	</properties>
 
-	<version>0.0.2</version>
 
 	<dependencies>
 		<dependency>
 			<groupId>org.into-cps.vdmcheck.fmi2</groupId>
 			<artifactId>static-model</artifactId>
-			<version>0.0.2</version>
+			<version>1.0.0-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>com.fujitsu</groupId>

--- a/fmi2/pom.xml
+++ b/fmi2/pom.xml
@@ -9,14 +9,13 @@
 	<parent>
 		<groupId>org.into-cps</groupId>
 		<artifactId>vdmcheck</artifactId>
-		<version>1.0.0</version>
+		<version>1.0.0-SNAPSHOT</version>
 	</parent>
 
 
 	<!-- parent pom -->
 	<groupId>org.into-cps.vdmcheck</groupId>
 	<artifactId>fmi2</artifactId>
-	<version>1.0.0</version>
 	<packaging>pom</packaging>
 
 	<!-- sub modules -->

--- a/fmi2/static-model/pom.xml
+++ b/fmi2/static-model/pom.xml
@@ -5,12 +5,11 @@
 	<parent>
 		<groupId>org.into-cps.vdmcheck</groupId>
 		<artifactId>fmi2</artifactId>
-		<version>1.0.0</version>
+		<version>1.0.0-SNAPSHOT</version>
 	</parent>
 
 	<groupId>org.into-cps.vdmcheck.fmi2</groupId>
 	<artifactId>static-model</artifactId>
-	<version>0.0.2</version>
 	<build>
 		<directory>generated</directory>
 		<plugins>

--- a/fmi3/fmi2vdm/pom.xml
+++ b/fmi3/fmi2vdm/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.into-cps.vdmcheck</groupId>
 		<artifactId>fmi3</artifactId>
-		<version>1.0.0</version>
+		<version>1.0.0-SNAPSHOT</version>
 	</parent>
 
 	<groupId>org.into-cps.vdmcheck.fmi3</groupId>
@@ -14,13 +14,12 @@
 		<maven.build.timestamp.format>yyMMdd</maven.build.timestamp.format>
 	</properties>
 
-	<version>0.0.3</version>
 
 	<dependencies>
 		<dependency>
 			<groupId>org.into-cps.vdmcheck.fmi3</groupId>
 			<artifactId>static-model</artifactId>
-			<version>0.0.3</version>
+			<version>1.0.0-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>com.fujitsu</groupId>

--- a/fmi3/pom.xml
+++ b/fmi3/pom.xml
@@ -9,14 +9,13 @@
 	<parent>
 		<groupId>org.into-cps</groupId>
 		<artifactId>vdmcheck</artifactId>
-		<version>1.0.0</version>
+		<version>1.0.0-SNAPSHOT</version>
 	</parent>
 
 
 	<!-- parent pom -->
 	<groupId>org.into-cps.vdmcheck</groupId>
 	<artifactId>fmi3</artifactId>
-	<version>1.0.0</version>
 	<packaging>pom</packaging>
 
 	<!-- sub modules -->

--- a/fmi3/static-model/pom.xml
+++ b/fmi3/static-model/pom.xml
@@ -5,12 +5,11 @@
 	<parent>
 		<groupId>org.into-cps.vdmcheck</groupId>
 		<artifactId>fmi3</artifactId>
-		<version>1.0.0</version>
+		<version>1.0.0-SNAPSHOT</version>
 	</parent>
 
 	<groupId>org.into-cps.vdmcheck.fmi3</groupId>
 	<artifactId>static-model</artifactId>
-	<version>0.0.3</version>
 	<build>
 		<directory>generated</directory>
 		<plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
     <!-- parent pom -->
     <groupId>org.into-cps</groupId>
     <artifactId>vdmcheck</artifactId>
-    <version>1.0.0</version>
+    <version>1.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <properties>


### PR DESCRIPTION
Added note about how to release and re-set all version numbers to one bundle with current version `1.0.0-SNAPSHOT` i.e. next release will be `1.0.0`